### PR TITLE
Fixing dfu.c to allow compiling with -Os

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ ST_LIB = stm32_lib
 ST_USB = usb_lib
 
 # Optimization level [0,1,2,3,s]
-OPT = 0
-DEBUG = -g
+OPT = s
+DEBUG = 
 #DEBUG = dwarf-2
 
 INCDIRS = ./$(ST_LIB) ./$(ST_USB)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ST_LIB = stm32_lib
 ST_USB = usb_lib
 
 # Optimization level [0,1,2,3,s]
-OPT = s
+OPT ?= 0
 DEBUG = 
 #DEBUG = dwarf-2
 

--- a/dfu.c
+++ b/dfu.c
@@ -41,7 +41,7 @@ static volatile DFUStatus dfuAppStatus;       /* includes state */
 static volatile bool userFlash = FALSE;
 volatile bool dfuBusy = FALSE;
 
-static volatile u8 recvBuffer[wTransferSize];
+static volatile u8 recvBuffer[wTransferSize] __attribute__((aligned(4)));
 static volatile u32 userFirmwareLen = 0;
 static volatile u16 thisBlockLen = 0;
 static volatile u16 uploadBlockLen = 0;

--- a/dfu.c
+++ b/dfu.c
@@ -363,7 +363,7 @@ void dfuCopyBufferToExec() {
         /* we dont need to handle when thisBlock len is not divisible by 4,
            since the linker will align everything to 4B anyway */
         for (i = 0; i < thisBlockLen; i = i + 4) {
-            *userSpace++ = *(u32 *)(recvBuffer+i);
+            *userSpace++ = *(u32 *)(recvBuffer + i);
         }
     } else {
         userSpace = (u32 *)(USER_CODE_FLASH + userFirmwareLen);

--- a/dfu.h
+++ b/dfu.h
@@ -93,7 +93,7 @@ typedef enum _PLOT {
 
 
 
-extern bool dfuBusy;
+extern volatile bool dfuBusy;
 
 /* exposed functions */
 void dfuInit(void);  /* singleton dfu initializer */


### PR DESCRIPTION
This fixes warnings and volatile variables, making the booloader working with -Os
Before this change, the bootloader was not able to upload any data with optimization enabled

This takes the bootloader size from ~16k to ~7k
